### PR TITLE
Update strategy

### DIFF
--- a/charts/proTES/templates/mongodb/mongodb-deployment.yaml
+++ b/charts/proTES/templates/mongodb/mongodb-deployment.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.mongodb.appName }}-{{ .Values.protes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proTES/templates/protes/celery-deployment.yaml
+++ b/charts/proTES/templates/protes/celery-deployment.yaml
@@ -7,9 +7,6 @@ spec:
     matchLabels:
       app: {{ .Values.celeryWorker.appName }}-{{ .Values.protes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proTES/templates/protes/protes-deployment.yaml
+++ b/charts/proTES/templates/protes/protes-deployment.yaml
@@ -8,9 +8,6 @@ spec:
     matchLabels:
       app: {{ .Values.protes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proTES/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/charts/proTES/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.rabbitmq.appName }}-{{ .Values.protes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proWES/templates/mongodb/mongodb-deployment.yaml
+++ b/charts/proWES/templates/mongodb/mongodb-deployment.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.mongodb.appName }}-{{ .Values.prowes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proWES/templates/prowes/celery-deployment.yaml
+++ b/charts/proWES/templates/prowes/celery-deployment.yaml
@@ -7,9 +7,6 @@ spec:
     matchLabels:
       app: {{ .Values.celeryWorker.appName }}-{{ .Values.prowes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proWES/templates/prowes/prowes-deployment.yaml
+++ b/charts/proWES/templates/prowes/prowes-deployment.yaml
@@ -8,9 +8,6 @@ spec:
     matchLabels:
       app: {{ .Values.prowes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/proWES/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/charts/proWES/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.rabbitmq.appName }}-{{ .Values.prowes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/tesk/templates/common/tesk-deployment.yaml
+++ b/charts/tesk/templates/common/tesk-deployment.yaml
@@ -8,9 +8,6 @@ spec:
       app: tesk-api
   replicas: 1
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/trs-filer/templates/mongo-deploy.yaml
+++ b/charts/trs-filer/templates/mongo-deploy.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: mongodb-{{ .Values.trs_filer.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/trs-filer/templates/trs-filer-deploy.yaml
+++ b/charts/trs-filer/templates/trs-filer-deploy.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.trs_filer.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/wes/templates/mongodb/mongodb-deployment.yaml
+++ b/charts/wes/templates/mongodb/mongodb-deployment.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.mongodb.appName }}-{{ .Values.wes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/wes/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/charts/wes/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -10,9 +10,6 @@ spec:
     matchLabels:
       app: {{ .Values.rabbitmq.appName }}-{{ .Values.wes.appName }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
     type: Recreate
   template:
     metadata:

--- a/charts/wes/templates/wes/celery-deployment.yaml
+++ b/charts/wes/templates/wes/celery-deployment.yaml
@@ -6,6 +6,8 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.celeryWorker.appName }}-{{ .Values.wes.appName }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/charts/wes/templates/wes/wes-deployment.yaml
+++ b/charts/wes/templates/wes/wes-deployment.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.wes.appName }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
When `type: Recreate` is specified, `rollingUpdate:` must not be precised